### PR TITLE
Fixing a bug where finding the right window wouldn't work.

### DIFF
--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -1597,13 +1597,16 @@ public class Manager : ArmchairManager {
     }
 
     private func getRootViewController() -> UIViewController? {
-        if let window = UIApplication.sharedApplication().keyWindow {
+        if var window = UIApplication.sharedApplication().keyWindow {
 
             if window.windowLevel != UIWindowLevelNormal {
                 var windows: NSArray = UIApplication.sharedApplication().windows
-                for window in windows {
-                    if window.windowLevel == UIWindowLevelNormal {
-                        break
+                for candidateWindow in windows {
+                    if let candidateWindow = candidateWindow as? UIWindow {
+                        if candidateWindow.windowLevel == UIWindowLevelNormal {
+                            window = candidateWindow
+                            break
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Now, even if you call rateApp() from a UIActionSheet, it will actually present the modal.

This logic seems to be broken currently. It searches for the right window, but never sets it to the local variable.
