### PR TITLE
adding the archived framework to the ignore list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Artwork
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+Armchair.framework.zip

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Artwork
 .Spotlight-V100
 .Trashes
 Armchair.framework.zip
+Carthage


### PR DESCRIPTION
Reference issue #31. 
There isn't much code to add to to this pull request. Required is to do the following for each release. 

`carthage build --no-skip-current`
`carthage archive Armchair`

Upload the generated `Armchair.framework.zip`(attached to this PR) which contains the frameworks to the release in github. 

[Armchair.framework.zip](https://github.com/UrbanApps/Armchair/files/57896/Armchair.framework.zip)
