### PR TITLE
Fix localization by getting the framework bundle

### DIFF
--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -1567,7 +1567,7 @@ public class Manager : ArmchairManager {
             if let url = armchairBundleURL {
                 bundle = NSBundle(URL: url)
             } else {
-                bundle = NSBundle.mainBundle()
+                bundle = NSBundle(forClass: self.dynamicType)
             }
         }
 


### PR DESCRIPTION
I use compiled framework (with cocoapod or carthage)
Localization does'nt work because main bundle is used (there is no .bundle)
So the fix allow to use the correct framework bundle