### PR TITLE
Allow to capture log using closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ The `debugEnabled` configuration is useful for testing how your review prompt po
 	GETTER: Armchair.debugEnabled() -> Bool
 	SETTER: Armchair.debugEnabled(debugEnabled: Bool)
 
+##### Logging
+  Armchair allows you to set a closure to capture debug log and to plug in the desired logging framework.
+
+	Armchair.logger(logger: ArmchairLogger)
+
 ##### iOS Only Configuration
 
 These configuration functions only make sense for iOS builds due to their dependency on iOS-only frameworks and functions.

--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -1715,13 +1715,19 @@ public class Manager : ArmchairManager {
     // MARK: -
     // MARK: Debug
 
+    public typealias ArmchairLogger = (Manager, log: String, file: StaticString, function: StaticString, line: UInt) -> Void
+
     let lockQueue = dispatch_queue_create("com.armchair.lockqueue", nil)
 
-    private func debugLog(log: String) {
-        if debugEnabled {
-            dispatch_sync(lockQueue, {
+    public var logger: ArmchairLogger = { manager, log, file, function, line in
+        if manager.debugEnabled {
+            dispatch_sync(manager.lockQueue, {
                 print("[Armchair] \(log)")
             })
         }
     }
+    private func debugLog(log: String, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__) {
+        logger(self, log: log, file: file, function: function, line: line)
+    }
+
 }

--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -563,6 +563,18 @@ public func shouldIncrementUseCountClosure(shouldIncrementUseCountClosure: Armch
     Manager.defaultManager.shouldIncrementUseCountClosure = shouldIncrementUseCountClosure
 }
 
+
+
+// MARK: Armchair Logger Protocol
+public typealias ArmchairLogger = (Manager, log: String, file: StaticString, function: StaticString, line: UInt) -> Void
+
+/*
+* Set a closure to capture debug log and to plug in the desired logging framework.
+*/
+public func logger(logger: ArmchairLogger) {
+    Manager.defaultManager.logger = logger
+}
+
 // MARK: -
 // MARK: Armchair Defaults Protocol
 
@@ -1714,8 +1726,6 @@ public class Manager : ArmchairManager {
 
     // MARK: -
     // MARK: Debug
-
-    public typealias ArmchairLogger = (Manager, log: String, file: StaticString, function: StaticString, line: UInt) -> Void
 
     let lockQueue = dispatch_queue_create("com.armchair.lockqueue", nil)
 


### PR DESCRIPTION
The main purpose is to allow end user to log using their preferred logger system ([CocoaLumberjack](https://github.com/CocoaLumberjack/CocoaLumberjack), [XCGLogger](https://github.com/DaveWoodCom/XCGLogger), [Loggerithm](https://github.com/honghaoz/Loggerithm), ...)
*(and in bonus this allow also to change formatting by adding, function, line)*

For instance with CocoaLumberjack
```swift
Manager.defaultManager.logger = { manager, log, file, function, line in
    DDLogDebug(log, file: file, function : function, line: line)
}
```

As I make it, this an hidden/advanced feature. I can go further if you want : 
- adding a global function
```swift
public func logger(logger: ArmchairLogger) {
    Manager.defaultManager.logger = logger
}
````
- add information in README (but english is not mother language)
```
#  in debug, in closure or in a new section Log?
Armchair allows you to set a closure to capture debug log and to plug in the desired logging framework.

Armchair.logger(logger: ArmchairLogger)

```