### PR TITLE
Replace `showPrompt(ifNecessary: Bool)` by `showPromptIfNecessary()` …

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,24 +121,24 @@ Run `carthage update` to build the framework and drag the built `Armchair.framew
 Armchair includes sensible defaults as well as reads data from your localized, or unlocalized `info.plist` to set itself up. While everything is configurable, the only **required** item to configure is your App Store ID. This call is the same for iOS and Mac apps, and should be made as part of your App Delegate's `initialize()` function
 
     Armchair.appID("12345678")
-        
+
 That's it to get started. Setting Armchair up with this line uses some sensible default criterion (detailed below) and will present a rating prompt whenever they are met.
 
 ### Custom Configuration
 
 Optionally, if you are using significant events in your app to track when the user does something of significance, add this line to any place where this event happens, such as a `levelDidFinish` function, or `userDidUploadPhoto` function.
- 
+
     Armchair.userDidSignificantEvent(true)
 
 In order for this to mean anything to Armchair, you also have to set the threshold for significant events. Typically, this, and all other logic configuration settings, should be made as part of your App Delegate's `initialize()` function so it can get the notifications on app launch.
 
     Armchair.significantEventsUntilPrompt(5)
-    
+
 As mentioned above, the `appID` is the only required item to configure. It is used to generate the URL that will link to the page. Most often, this is configured to the App that is currently running, but there may be an instance where you want to set it to another app, such as in an App that reviews other Apps.
 
     GETTER: Armchair.appID() -> String
     SETTER: Armchair.appID(appID: String)
-    
+
 ##### Display Strings
 
 The `appName` is used in several places on the review prompt popup. It can be configured here to customize your message without losing any of the default localizations. By default, Armchair will read the value from your localized, or unlocalized `info.plist`, but you can set it specifically if you want.
@@ -183,10 +183,10 @@ The `usesUntilPrompt` configuration determines how many times the user will need
 	GETTER: Armchair.usesUntilPrompt() -> UInt
 	SETTER: Armchair.usesUntilPrompt(usesUntilPrompt: UInt)
 
-An example of a 'use' would be if the user launched the app, or brings it to the foreground. Armchair keeps track of these internally by listening to UIApplication/NSApplication lifecycle notifications. 
+An example of a 'use' would be if the user launched the app, or brings it to the foreground. Armchair keeps track of these internally by listening to UIApplication/NSApplication lifecycle notifications.
 
 As discussed briefly above, the `significantEventsUntilPrompt` configuration determines how many "significant events" the user will need to have before they will be prompted to rate the App. It defaults to 0 significant events.
-	
+
     GETTER: Armchair.significantEventsUntilPrompt() -> UInt
     SETTER: Armchair.significantEventsUntilPrompt(significantEventsUntilPrompt: UInt)
 
@@ -195,7 +195,7 @@ A significant event can be anything you want to be in your app. In a telephone a
     Armchair.userDidSignificantEvent(canPromptForRating: Bool)
 
 The `daysBeforeReminding` configuration determines how many days Armchair will wait before reminding the user to rate again, should they select the "Remind Me Later" option on the first alert. It defaults to 1 day. A value of 0 will remove the "Remind Me Later" button and disable this feature.
-	
+
 	GETTER: Armchair.daysBeforeReminding() -> UInt
 	SETTER: Armchair.daysBeforeReminding(daysBeforeReminding: UInt)
 
@@ -205,15 +205,15 @@ The `tracksNewVersions` configuration determines whether or not Armchair should 
 	SETTER: Armchair.tracksNewVersions(tracksNewVersions: Bool)
 
 The `shouldPromptIfRated` configuration determines whether or not to show the review prompt to users who have rated the app once before. This setting is a little like the `tracksNewVersions` setting, but a little less nuclear. Setting this to `false` will cause new users of the app to get the popup, but won't ask users who have already been asked for a popup in the past. This is useful if you release small bug-fix versions and don't want to pester your existing users with popups for every minor version, but want to ensure new users get prompted for a review. For example, you might set this to false for every minor build, then when you push a major version upgrade, leave it as true to ask for a rating again. Its default value is `true`.
-	
+
     GETTER: Armchair.shouldPromptIfRated() -> Bool
 	SETTER: Armchair.shouldPromptIfRated(shouldPromptIfRated: Bool)
 
 The `useMainAppBundleForLocalizations` configuration is a way to tell Armchair that you are providing your own translations for the review prompt popup strings. This may be because you are just customizing them, or that you have set your own text for the popup. If set to `true`, the main bundle will always be used to load localized strings. If set to `false` Armchair will look in its own translation bundle for the translating strings. It's default value is `false`.
-	
+
 	GETTER: Armchair.useMainAppBundleForLocalizations() -> Bool
 	SETTER: Armchair.useMainAppBundleForLocalizations(useMainAppBundleForLocalizations: Bool)
-	
+
 ##### Affiliate Codes
 
 The `affiliateCode` configuration is optional and is used to configure with the review URL. If you are an Apple Affiliate, enter your code here. If none is set, the author's code will be used as it is better to be set as something rather than nothing. If you want to thank me for making Armchair, feel free to leave this value at it's default.
@@ -223,14 +223,14 @@ The `affiliateCode` configuration is optional and is used to configure with the 
     SETTER: Armchair.affiliateCode(affiliateCode: String)
 
 The `affiliateCampaignCode` configuration is optional and is used to configure the review URL. It provides context to the affiliate code and defaults to "Armchair-\<appID\>".
-	
+
     GETTER: Armchair.affiliateCampaignCode() -> String
     SETTER: Armchair.affiliateCampaignCode(affiliateCampaignCode: String)
 
 ##### Debug Mode
 
 The `debugEnabled` configuration is useful for testing how your review prompt popup looks and for testing. Setting it to `true` will show the Armchair alert every time by tricking the app into thinking the conditions for a prompt have been met. Calling this function in a production build (determined when `Debug` swift compiler flag is *not* defined) has no effect. In App Store builds, you don't have to worry about accidentally leaving debug on. The default value of `debugEnabled` is `false`.
-	
+
 	GETTER: Armchair.debugEnabled() -> Bool
 	SETTER: Armchair.debugEnabled(debugEnabled: Bool)
 
@@ -244,15 +244,15 @@ The `usesAnimation` configuration determines whether or not Armchair uses animat
 	SETTER: Armchair.usesAnimation(usesAnimation: Bool)
 
 The `usesAlertController` configuration determines whether or not Armchair uses a UIAlertController when presenting an alert on iOS 8. By default, we do not use it because the reordering of buttons is not possible in the alert controller as of iOS 8.0. It's default value is `false`. Changing this value does not affect iOS 7 at all.
-    
+
 	GETTER: Armchair.usesAlertController() -> Bool
 	SETTER: Armchair.usesAlertController(usesAnimation: Bool)
-	
+
 The `opensInStoreKit` configuration determines if Armchair will open the App Store link inside the App using a `SKStoreProductViewController`. By default, this is `false` on iOS 7, and `true` on iOS 8.
-	
+
     GETTER: Armchair.opensInStoreKit() -> Bool
 	SETTER: Armchair.opensInStoreKit(opensInStoreKit: Bool)
-    
+
 There are 2 reasons why the default is `false` on iOS 7.
 
 - The SKStoreProductViewController __does not allow the user to write a review__ (as of iOS 7)!
@@ -273,11 +273,11 @@ Read more about these functions below in the [Should-Prompt Closure](#should-pro
 
 `showPrompt()` tells Armchair to show the review prompt alert. The prompt will be showed if there is an internet connection available, the user hasn't already declined to rate, hasn't rated the current version and you are tracking new versions. You could call to show the prompt regardless of Armchair settings, for instance, in the case of some special event in your app like positive feedback given.
 
-	Armchair.showPrompt()
+    Armchair.showPrompt()
 
-`showPrompt(ifNecessary: Bool)` tells Armchair to show the review prompt alert if all restrictions have been met. The prompt will be shown if all restrictions are met, there is an internet connection available, the user hasn't declined to rate, hasn't rated current version, and you are tracking new versions. You could call to show the prompt, for instance, in the case of some special event in your app like a user login.
+`showPromptIfNecessary()` tells Armchair to show the review prompt alert if all restrictions have been met. The prompt will be shown if all restrictions are met, there is an internet connection available, the user hasn't declined to rate, hasn't rated current version, and you are tracking new versions. You could call to show the prompt, for instance, in the case of some special event in your app like a user login.
 
-    Armchair.showPrompt(ifNecessary: Bool)
+    Armchair.showPromptIfNecessary()
 
 The `reviewURLString()` function is the review URL string, generated by substituting the `appID`, `affiliateCode` and `affiliateCampaignCode` into the template URL for the current platform.
 
@@ -296,7 +296,7 @@ The `reviewURLString()` function is the review URL string, generated by substitu
 ### Closures
 
 Armchair uses optional closures instead of delegate functions for callbacks. Default is nil for all of them.
-	
+
     Armchair.onDidDisplayAlert(didDisplayAlertClosure: ArmchairClosure?)
     Armchair.onDidDeclineToRate(didDeclineToRateClosure: ArmchairClosure?)
     Armchair.onDidOptToRate(didOptToRateClosure: ArmchairClosure?)
@@ -316,19 +316,19 @@ By default Armchair increments the use count every time the app enters the foreg
 ##### Should-Prompt Closure
 
 Armchair allows you to set a closure that is called immediately preceding the display of the popup.
-	
+
 	public typealias ArmchairShouldPromptClosure = (ArmchairTrackingInfo) -> Bool
-    
+
 The `ArmchairShouldPromptClosure` passes you the keys and values Armchair used to determine that the prompt should be called (found in the ArmchairTrackingInfo's `info` dictionary), and expects a `Bool` return value on whether or not the prompt should still be displayed. This allows you to have one last chance to do any of your own custom logic to determine whether or not this is an appropriate time to display the prompt.
 
     Armchair.shouldPromptClosure(shouldPromptClosure: ArmchairShouldPromptClosure?)
-    
+
 
 In addition to the global `shouldPromptClosure`, the Armchair functions that trigger the presentation of the prompt (`showPrompt(ifNecessary: Bool)` and `userDidSignificantEvent()`) have their own closure based variant that allows you to customize whether or not this is an appropriate time to display the prompt.
 
     Armchair.showPrompt(shouldPrompt: ArmchairShouldPromptClosure)
     Armchair.userDidSignificantEvent(shouldPrompt: ArmchairShouldPromptClosure)
-    
+
 When using these functions instead of their `Bool` sister-functions, none of the internal Armchair logic is used to determine whether or not to display the prompt. **Only** your closure is used to decide whether or not it should be presented, based solely on the return value you pass back in the closure. This also means that even the global `shouldPromptClosure()` (if set) will not be called when using these functions.
 
 **Note:** The `shouldPromptClosure()` is run synchronous and on the main queue, so be sure to handle it appropriately.
@@ -360,16 +360,16 @@ The `userDefaultsObject` can be any object that responds to the `ArmchairDefault
     	func setInteger(value: Int, forKey defaultName: String)
     	func setDouble(value: Double, forKey defaultName: String)
     	func setBool(value: Bool, forKey defaultName: String)
-    
+
     	func synchronize() -> Bool
 	}
 
 So, to use it with iCloud and the `NSUbiquitousKeyValueStore`, set up like so:
 
     Armchair.userDefaultsObject(NSUbiquitousKeyValueStoreSubclass.defaultStore())
-    
+
 ...where you have a subclass that conforms to the protocol.
-    
+
 You can get/set the `keyPrefix` to the keys above that store the usage data for Armchair. The default value  is the `appID`, and it is prepended to the keys for key type. Setting a `keyPrefix` prevents different apps using a shared Key/Value store from overwriting each other.
 
     GETTER Armchair.keyPrefix() -> String


### PR DESCRIPTION
…in README.md
+ Remove Extra/Unwanted Spaces

In global function we have `Armchair.showPromptIfNecessary()` in the code, not `Armchair.showPrompt(ifNecessary: Bool)` as described in current readme

but in manager we have `manager.showPrompt(ifNecessary: Bool)`, but I think readme.md talk about global function `Armchair.`
