### PR TITLE
Removed warnings when compiling with Swift 2.2.

### DIFF
--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -999,11 +999,12 @@ public class Manager : ArmchairManager {
             }
 
             // Increment the key's count
-            var incrementKeyCount = userDefaultsObject?.integerForKey(incrementKey)
-            userDefaultsObject?.setInteger(++incrementKeyCount!, forKey:incrementKey)
+            if var incrementKeyCount = userDefaultsObject?.integerForKey(incrementKey) {
+                incrementKeyCount += 1
 
-            debugLog("Incremented \(incrementKeyType): \(incrementKeyCount!)")
-
+                userDefaultsObject?.setInteger(incrementKeyCount, forKey: incrementKey)
+                debugLog("Incremented \(incrementKeyType): \(incrementKeyCount)")
+            }
         } else if tracksNewVersions {
             // it's a new version of the app, so restart tracking
             resetAllCounters()
@@ -1734,9 +1735,9 @@ public class Manager : ArmchairManager {
 
     private func setupNotifications() {
 #if os(iOS)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "appWillResignActive:",            name: UIApplicationWillResignActiveNotification,    object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationDidFinishLaunching:",  name: UIApplicationDidFinishLaunchingNotification,  object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationWillEnterForeground:", name: UIApplicationWillEnterForegroundNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(appWillResignActive(_:)),            name: UIApplicationWillResignActiveNotification,    object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(applicationDidFinishLaunching(_:)),  name: UIApplicationDidFinishLaunchingNotification,  object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(applicationWillEnterForeground(_:)), name: UIApplicationWillEnterForegroundNotification, object: nil)
 #elseif os(OSX)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "appWillResignActive:",            name: NSApplicationWillResignActiveNotification,    object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationDidFinishLaunching:",  name: NSApplicationDidFinishLaunchingNotification,  object: nil)
@@ -1765,7 +1766,7 @@ public class Manager : ArmchairManager {
             })
         }
     }
-    private func debugLog(log: String, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__) {
+    private func debugLog(log: String, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
         logger(self, log: log, file: file, function: function, line: line)
     }
 


### PR DESCRIPTION
We're using Swift 2.2 and Armchair in our project, which causes warnings when we build. This gets rid of those warnings when building with Swift 2.2.
