### PR TITLE
Fallback to localizable.strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Armchair.shouldPromptIfRated() -> Bool
 Armchair.shouldPromptIfRated(shouldPromptIfRated: Bool)
 ```
 
-The `useMainAppBundleForLocalizations` configuration is a way to tell Armchair that you are providing your own translations for the review prompt popup strings. This may be because you are just customizing them, or that you have set your own text for the popup. If set to `true`, the main bundle will always be used to load localized strings. If set to `false` Armchair will look in its own translation bundle for the translating strings. It's default value is `false`.
+The `useMainAppBundleForLocalizations` configuration is a way to tell Armchair that you are providing your own translations for the review prompt popup strings. This may be because you are just customizing them, or that you have set your own text for the popup. If set to `true`, the main bundle will always be used to load localized strings. You have to include the translations either in a file called `ArmchairLocalizable.strings` or the standard `Localizable.strings`. If set to `false` Armchair will look in its own translation bundle for the translating strings. It's default value is `false`.
 
 ```swift
 // GETTER

--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -750,7 +750,9 @@ public class Manager : ArmchairManager {
         var template = "Rate %@"
         // Check for a localized version of the default title
         if let bundle = self.bundle() {
-            template = bundle.localizedStringForKey(template, value:"", table: "ArmchairLocalizable")
+            template = bundle.localizedStringForKey(template,
+                                                    value: bundle.localizedStringForKey(template, value:"", table: nil),
+                                                    table: "ArmchairLocalizable")
         }
 
         return template.stringByReplacingOccurrencesOfString("%@", withString: "\(self.appName)", options: NSStringCompareOptions(rawValue: 0), range: nil)
@@ -761,7 +763,9 @@ public class Manager : ArmchairManager {
         var template = "If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!"
         // Check for a localized version of the default title
         if let bundle = self.bundle() {
-            template = bundle.localizedStringForKey(template, value:"", table: "ArmchairLocalizable")
+            template = bundle.localizedStringForKey(template,
+                                                    value: bundle.localizedStringForKey(template, value:"", table: nil),
+                                                    table: "ArmchairLocalizable")
         }
 
         return template.stringByReplacingOccurrencesOfString("%@", withString: "\(self.appName)", options: NSStringCompareOptions(rawValue: 0), range: nil)
@@ -772,7 +776,9 @@ public class Manager : ArmchairManager {
         var title = "No, Thanks"
         // Check for a localized version of the default title
         if let bundle = self.bundle() {
-            title = bundle.localizedStringForKey(title, value:"", table: "ArmchairLocalizable")
+            title = bundle.localizedStringForKey(title,
+                                                 value: bundle.localizedStringForKey(title, value:"", table: nil),
+                                                 table: "ArmchairLocalizable")
         }
 
         return title
@@ -783,7 +789,9 @@ public class Manager : ArmchairManager {
         var template = "Rate %@"
         // Check for a localized version of the default title
         if let bundle = self.bundle() {
-            template = bundle.localizedStringForKey(template, value:"", table: "ArmchairLocalizable")
+            template = bundle.localizedStringForKey(template,
+                                                    value: bundle.localizedStringForKey(template, value:"", table: nil),
+                                                    table: "ArmchairLocalizable")
         }
 
         return template.stringByReplacingOccurrencesOfString("%@", withString: "\(self.appName)", options: NSStringCompareOptions(rawValue: 0), range: nil)
@@ -798,7 +806,9 @@ public class Manager : ArmchairManager {
         var title = "Remind me later"
         // Check for a localized version of the default title
         if let bundle = self.bundle() {
-            title = bundle.localizedStringForKey(title, value:"", table: "ArmchairLocalizable")
+            title = bundle.localizedStringForKey(title,
+                                                 value: bundle.localizedStringForKey(title, value:"", table: nil),
+                                                 table: "ArmchairLocalizable")
         }
 
         return title


### PR DESCRIPTION
- `ArmchairLocalizable.strings` wasn't documented in the Readme so one wouldn't know where to put the translation strings.
- Many projects use the standard `Localizable.strings` file so this should be included in the defaults.

In order not to break functionality for existing installations I have included a fallback from `ArmchairLocalizable.strings` to `Localizable.strings`.