### PR TITLE
Add tintColor configuration setting

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -141,6 +141,9 @@ extension ViewController {
         #if os(iOS)
             // Explicitly disable the storeKit as the default may be true if on iOS 8
             Armchair.opensInStoreKit(false)
+            
+            // This sets a custom tint color  (applies only to UIAlertController).
+            Armchair.tintColor(UIColor.brownColor())
         #endif
 
         // This sets the Affiliate code you want to use, but is not required.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,15 @@ Armchair.usesAnimation() -> Bool
 Armchair.usesAnimation(usesAnimation: Bool)
 ```
 
+The `tintColor` configuration specifies a tint color that is applied to UIAlertController when `usesAlertController` is true. Its default value is `nil`, which means that tint color is not customized.
+
+```swift
+// GETTER
+Armchair.tintColor() -> UIColor?
+// SETTER
+Armchair.tintColor(tintColor: UIColor?)
+```
+
 The `usesAlertController` configuration determines whether or not Armchair uses a UIAlertController when presenting an alert on iOS 8. By default, we do not use it because the reordering of buttons is not possible in the alert controller as of iOS 8.0. It's default value is `false`. Changing this value does not affect iOS 7 at all.
 
 ```swift

--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -359,6 +359,7 @@ public func resetDefaults() {
 
 #if os(iOS)
     Manager.defaultManager.usesAnimation                    = true
+    Manager.defaultManager.tintColor                        = nil
     Manager.defaultManager.usesAlertController              = Manager.defaultManager.defaultUsesAlertController()
     Manager.defaultManager.opensInStoreKit                  = Manager.defaultManager.defaultOpensInStoreKit()
     Manager.defaultManager.willPresentModalViewClosure      = nil
@@ -394,7 +395,18 @@ public func resetDefaults() {
     public func usesAnimation(usesAnimation: Bool) {
         Manager.defaultManager.usesAnimation = usesAnimation
     }
-
+    
+    /*
+    * Set a tint color to apply to UIAlertController
+    * Default => nil (the default tint color is used)
+    */
+    public func tintColor() -> UIColor? {
+        return Manager.defaultManager.tintColor
+    }
+    public func tintColor(tintColor: UIColor?) {
+        Manager.defaultManager.tintColor = tintColor
+    }
+    
     /*
     * Set whether or not Armchair uses a UIAlertController when presenting on iOS 8
     * We prefer not to use it so that the Rate button can be on the bottom and the cancel button on the top,
@@ -847,6 +859,7 @@ public class Manager : ArmchairManager {
 
 #if os(iOS)
     private var usesAnimation: Bool                     = true
+    private var tintColor: UIColor?                     = nil
     private lazy var usesAlertController: Bool          = self.defaultUsesAlertController()
     private lazy var opensInStoreKit: Bool              = self.defaultOpensInStoreKit()
 
@@ -1192,6 +1205,8 @@ public class Manager : ArmchairManager {
                     topController.presentViewController(alertView, animated: usesAnimation) {
                         print("presentViewController() completed")
                     }
+                    // note that tint color has to be set after the controller is presented in order to take effect (last checked in iOS 9.3)
+                    alertView.view.tintColor = tintColor
                 }
             }
 


### PR DESCRIPTION
I've introduced a new configuration option `tintColor` that allows to apply a custom tint color to rating alert. It's iOS-only and unfortunately works only with `UIAlertController` (there's no way of changing `UIAlertView`'s tint color as far as I know).