### PR TITLE
Fixed issue with Carthage building project using the wrong toolchain

### DIFF
--- a/Armchair.xcodeproj/project.pbxproj
+++ b/Armchair.xcodeproj/project.pbxproj
@@ -725,7 +725,6 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
-
 			};
 			name = Debug;
 		};
@@ -747,7 +746,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-        SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
When building through Carthage, the Release config is being used and fails to build using the Swift 2.3 toolchain.