### PR TITLE
Add support for iOS 10.3 review prompt

### DIFF
--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -70,6 +70,18 @@ public func reviewTitle(_ reviewTitle: String) {
 }
 
 /*
+ * If set to true, use SKStoreReviewController's requestReview() prompt instead of the default prompt.
+ * If not on iOS 10.3+, reort to the default prompt.
+ * Default => false.
+ */
+public func useStoreKitReviewPrompt() -> Bool {
+    return Manager.defaultManager.useStoreKitReviewPrompt
+}
+public func useStoreKitReviewPrompt(_ useStoreKitReviewPrompt: Bool) {
+    Manager.defaultManager.useStoreKitReviewPrompt = useStoreKitReviewPrompt
+}
+
+/*
  * Get/Set the message to use on the review prompt.
  * Default value is a localized
  *  "If you enjoy using <appName>, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!"
@@ -870,6 +882,7 @@ open class Manager : ArmchairManager {
     fileprivate var tintColor: UIColor?                     = nil
     fileprivate lazy var usesAlertController: Bool          = self.defaultUsesAlertController()
     fileprivate lazy var opensInStoreKit: Bool              = self.defaultOpensInStoreKit()
+    fileprivate var useStoreKitReviewPrompt: Bool           = false
 
     fileprivate func defaultOpensInStoreKit() -> Bool {
         return operatingSystemVersion >= 8
@@ -1199,6 +1212,10 @@ open class Manager : ArmchairManager {
             }
         } else {
             #if os(iOS)
+                if #available(iOS 10.3, *), useStoreKitReviewPrompt {
+                    SKStoreReviewController.requestReview()
+                    return
+                }
                 if (operatingSystemVersion >= 8 && usesAlertController) || operatingSystemVersion >= 9 {
                     /* iOS 8 uses new UIAlertController API*/
                     let alertView : UIAlertController = UIAlertController(title: reviewTitle, message: reviewMessage, preferredStyle: UIAlertControllerStyle.alert)


### PR DESCRIPTION
Added an option to use SKStoreReviewController review prompt instead of the default prompt. If it’s not available (below iOS 10.3), just use the default prompt.

Relates to #85 