### PR TITLE
Fix infinite prompts when using StoreKit prompt

### DIFF
--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -1214,6 +1214,10 @@ open class Manager : ArmchairManager {
             #if os(iOS)
                 if #available(iOS 10.3, *), useStoreKitReviewPrompt {
                     SKStoreReviewController.requestReview()
+                    // Assume this version is rated. There is no API to tell if the user actaully rated.
+                    userDefaultsObject?.setBool(true, forKey: keyForArmchairKeyType(ArmchairKey.RatedCurrentVersion))
+                    userDefaultsObject?.setBool(true, forKey: keyForArmchairKeyType(ArmchairKey.RatedAnyVersion))
+                    userDefaultsObject?.synchronize()
                     return
                 }
                 if (operatingSystemVersion >= 8 && usesAlertController) || operatingSystemVersion >= 9 {


### PR DESCRIPTION
If using the storekit prompt, assume that the user rated the app when the prompt is presented.
This fixes infinite prompts when rating conditions have been met.

Relates to #93 