### PR TITLE
Fix issue when `getRootViewController` would return `nil`

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -28,7 +28,7 @@
     class AppDelegate: UIResponder, UIApplicationDelegate {
         var window: UIWindow?
         
-        func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
             return true
         }
     }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -55,12 +55,12 @@ extension ViewController {
 
         // Only set it if we are using Armchair localizations
         if !Armchair.useMainAppBundleForLocalizations() {
-            let currentLocalization: NSString = NSBundle.mainBundle().preferredLocalizations[0] as NSString
+            let currentLocalization: NSString = Bundle.main.preferredLocalizations[0] as NSString
             // Only set it if we are using a different language than this apps development language
-            if let developmentLocalization = NSBundle.mainBundle().developmentLocalization {
-                if currentLocalization != developmentLocalization {
+            if let developmentLocalization = Bundle.main.developmentLocalization {
+                if currentLocalization as String != developmentLocalization {
                     languageLabelText = currentLocalization as String
-                    if let displayName = NSLocale(localeIdentifier: currentLocalization as String).displayNameForKey(NSLocaleIdentifier, value:currentLocalization) {
+                    if let displayName = (Locale(identifier: currentLocalization as String) as NSLocale).displayName(forKey: NSLocale.Key.identifier, value:currentLocalization) {
                         languageLabelText = "\(displayName): \(currentLocalization)"
                     }
                 }
@@ -143,7 +143,7 @@ extension ViewController {
             Armchair.opensInStoreKit(false)
             
             // This sets a custom tint color  (applies only to UIAlertController).
-            Armchair.tintColor(UIColor.brownColor())
+            Armchair.tintColor(tintColor: UIColor.brown)
         #endif
 
         // This sets the Affiliate code you want to use, but is not required.
@@ -216,9 +216,9 @@ extension ViewController {
     }
     
     @IBAction func openUrbanApps(_: AnyObject) {
-        if let url = NSURL(string: "http://urbanapps.com") {
+        if let url = URL(string: "http://urbanapps.com") {
 #if os(iOS)
-            UIApplication.sharedApplication().openURL(url)
+            UIApplication.shared.openURL(url)
 #elseif os(OSX)
             NSWorkspace.sharedWorkspace().openURL(url)
 #else

--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -1240,7 +1240,7 @@ open class Manager : ArmchairManager {
                     
                     // get the top most controller (= the StoreKit Controller) and dismiss it
                     if let presentingController = UIApplication.shared.keyWindow?.rootViewController {
-                        if let topController = topMostViewController(presentingController) {
+                        if let topController = Manager.topMostViewController(presentingController) {
                             topController.present(alertView, animated: usesAnimation) { [weak self] _ in
                                 if let closure = self?.didDisplayAlertClosure {
                                     closure()
@@ -1335,7 +1335,7 @@ open class Manager : ArmchairManager {
             
             // get the top most controller (= the StoreKit Controller) and dismiss it
             if let presentingController = UIApplication.shared.keyWindow?.rootViewController {
-                if let topController = topMostViewController(presentingController) {
+                if let topController = Manager.topMostViewController(presentingController) {
                     topController.dismiss(animated: usesAnimation) {
                         if let closure = self.didDismissModalViewClosure {
                             closure(usedAnimation)
@@ -1422,7 +1422,7 @@ open class Manager : ArmchairManager {
                 }
                 
                 
-                if let rootController = getRootViewController() {
+                if let rootController = Manager.getRootViewController() {
                     rootController.present(storeViewController, animated: usesAnimation) {
                         self.modalPanelOpen = true
                         
@@ -1689,7 +1689,7 @@ open class Manager : ArmchairManager {
     }
     
     #if os(iOS)
-    private func topMostViewController(_ controller: UIViewController?) -> UIViewController? {
+    private static func topMostViewController(_ controller: UIViewController?) -> UIViewController? {
         var isPresenting: Bool = false
         var topController: UIViewController? = controller
         repeat {
@@ -1707,7 +1707,7 @@ open class Manager : ArmchairManager {
         return topController
     }
     
-    private func getRootViewController() -> UIViewController? {
+    private static func getRootViewController() -> UIViewController? {
         if var window = UIApplication.shared.keyWindow {
             
             if window.windowLevel != UIWindowLevelNormal {
@@ -1722,20 +1722,30 @@ open class Manager : ArmchairManager {
                 }
             }
             
-            for subView in window.subviews {
-                if let responder = subView.next {
-                    if responder.isKind(of: UIViewController.self) {
-                        return topMostViewController(responder as? UIViewController)
-                    }
-                    
-                }
-            }
+            return iterateSubViewsForViewController(window)
         }
         
         return nil
     }
+
+    private static func iterateSubViewsForViewController(_ parentView: UIView) -> UIViewController? {
+        for subView in parentView.subviews {
+            if let responder = subView.next {
+                if responder.isKind(of: UIViewController.self) {
+                    return topMostViewController(responder as? UIViewController)
+                }
+            }
+
+            if let found = iterateSubViewsForViewController(subView) {
+                return found
+            }
+        }
+
+        return nil
+    }
+
     #endif
-    
+
     private func hideRatingAlert() {
         if let alert = ratingAlert {
             debugLog("Hiding Alert")

--- a/iOS Example.xcodeproj/project.pbxproj
+++ b/iOS Example.xcodeproj/project.pbxproj
@@ -194,7 +194,7 @@
 					F8111E0419A951050040E7D1 = {
 						CreatedOnToolsVersion = 6.0;
 						DevelopmentTeam = 9H3S97RP4K;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -422,7 +422,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.armchair.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS Example";
 				PROVISIONING_PROFILE = "";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -440,7 +440,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.armchair.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS Example";
 				PROVISIONING_PROFILE = "";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Depending the way the application is built, getting the root view controller would eventually return a `nil` value.

This fix makes sure to recursively iterate over subviews of the window to find the rootViewController.