### PR TITLE
Update Armchair podspec

### DIFF
--- a/Armchair.podspec
+++ b/Armchair.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
 
   s.source_files          = "Source/*.{h,swift}"
   s.resources             = "Localization/*.lproj"
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'
   s.requires_arc          = true
   s.swift_version         = '5.0'


### PR DESCRIPTION


<img width="457" alt="Screen Shot 2020-11-08 at 10 04 00 PM" src="https://user-images.githubusercontent.com/1163880/98496239-2b39e380-220f-11eb-9cfa-6b8bbe0c354d.png">
Updates the podspec to minimum of ios9 to resolve a warning in xcode 12+